### PR TITLE
Don't check if trial's metadata in experiment parameters

### DIFF
--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -179,4 +179,14 @@ var (
 	DefaultKatibDBManagerServiceIP = env.GetEnvOrDefault(DefaultKatibDBManagerServiceIPEnvName, "katib-db-manager")
 	// DefaultKatibDBManagerServicePort is the default Port of Katib DB Manager
 	DefaultKatibDBManagerServicePort = env.GetEnvOrDefault(DefaultKatibDBManagerServicePortEnvName, "6789")
+
+	// List of all valid keys of trial metadata for substitution in Trial template
+	TrialTemplateMetaKeys = []string{
+		TrialTemplateMetaKeyOfName,
+		TrialTemplateMetaKeyOfNamespace,
+		TrialTemplateMetaKeyOfKind,
+		TrialTemplateMetaKeyOfAPIVersion,
+		TrialTemplateMetaKeyOfAnnotations,
+		TrialTemplateMetaKeyOfLabels,
+	}
 )

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -311,8 +311,13 @@ func (g *DefaultValidator) validateTrialTemplate(instance *experimentsv1beta1.Ex
 
 		// Check if parameter reference exist in experiment parameters
 		if len(experimentParameterNames) > 0 {
-			if _, ok := experimentParameterNames[parameter.Reference]; !ok {
-				return fmt.Errorf("parameter reference %v does not exist in spec.parameters: %v", parameter.Reference, instance.Spec.Parameters)
+			// Check if parameter is trial metadata
+			regex := regexp.MustCompile(consts.TrialTemplateMetaReplaceFormatRegex)
+			match := regex.FindStringSubmatch(parameter.Reference)
+			if !(len(match) > 0 && contains(consts.TrialTemplateMetaKeys, match[1])) {
+				if _, ok := experimentParameterNames[parameter.Reference]; !ok {
+					return fmt.Errorf("parameter reference %v does not exist in spec.parameters: %v", parameter.Reference, instance.Spec.Parameters)
+				}
 			}
 		}
 
@@ -480,4 +485,13 @@ func (g *DefaultValidator) validateMetricsCollector(inst *experimentsv1beta1.Exp
 	}
 
 	return nil
+}
+
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/webhook/v1beta1/experiment/validator/validator_test.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator_test.go
@@ -810,7 +810,8 @@ func TestValidateMetricsCollector(t *testing.T) {
 					},
 					Source: &commonv1beta1.SourceSpec{
 						FileSystemPath: &commonv1beta1.FileSystemPath{
-							Path: "not/absolute/path",
+							Path:   "not/absolute/path",
+							Format: commonv1beta1.TextFormat,
 						},
 					},
 				}
@@ -837,6 +838,27 @@ func TestValidateMetricsCollector(t *testing.T) {
 			}(),
 			Err:             true,
 			testDescription: "Invalid path for TF event metrics collector",
+		},
+		// TfEventCollector invalid file format
+		{
+			Instance: func() *experimentsv1beta1.Experiment {
+				i := newFakeInstance()
+				i.Spec.MetricsCollectorSpec = &commonv1beta1.MetricsCollectorSpec{
+					Collector: &commonv1beta1.CollectorSpec{
+						Kind: commonv1beta1.TfEventCollector,
+					},
+					Source: &commonv1beta1.SourceSpec{
+						FileSystemPath: &commonv1beta1.FileSystemPath{
+							Path:   "/absolute/path",
+							Format: commonv1beta1.JsonFormat,
+							Kind:   commonv1beta1.DirectoryKind,
+						},
+					},
+				}
+				return i
+			}(),
+			Err:             true,
+			testDescription: "Invalid file format for TF event metrics collector",
 		},
 		// PrometheusMetricCollector invalid Port
 		{
@@ -932,8 +954,9 @@ func TestValidateMetricsCollector(t *testing.T) {
 							},
 						},
 						FileSystemPath: &commonv1beta1.FileSystemPath{
-							Path: "/absolute/path",
-							Kind: commonv1beta1.FileKind,
+							Path:   "/absolute/path",
+							Kind:   commonv1beta1.FileKind,
+							Format: commonv1beta1.TextFormat,
 						},
 					},
 				}
@@ -957,8 +980,9 @@ func TestValidateMetricsCollector(t *testing.T) {
 							},
 						},
 						FileSystemPath: &commonv1beta1.FileSystemPath{
-							Path: "/absolute/path",
-							Kind: commonv1beta1.FileKind,
+							Path:   "/absolute/path",
+							Kind:   commonv1beta1.FileKind,
+							Format: commonv1beta1.TextFormat,
 						},
 					},
 				}
@@ -966,6 +990,49 @@ func TestValidateMetricsCollector(t *testing.T) {
 			}(),
 			Err:             true,
 			testDescription: "One subexpression in metrics format",
+		},
+		// FileMetricCollector invalid file format
+		{
+			Instance: func() *experimentsv1beta1.Experiment {
+				i := newFakeInstance()
+				i.Spec.MetricsCollectorSpec = &commonv1beta1.MetricsCollectorSpec{
+					Collector: &commonv1beta1.CollectorSpec{
+						Kind: commonv1beta1.FileCollector,
+					},
+					Source: &commonv1beta1.SourceSpec{
+						FileSystemPath: &commonv1beta1.FileSystemPath{
+							Path:   "/absolute/path",
+							Kind:   commonv1beta1.FileKind,
+							Format: "invalid",
+						},
+					},
+				}
+				return i
+			}(),
+			Err:             true,
+			testDescription: "Invalid file format for File metrics collector",
+		},
+		// FileMetricCollector invalid metrics filter
+		{
+			Instance: func() *experimentsv1beta1.Experiment {
+				i := newFakeInstance()
+				i.Spec.MetricsCollectorSpec = &commonv1beta1.MetricsCollectorSpec{
+					Collector: &commonv1beta1.CollectorSpec{
+						Kind: commonv1beta1.FileCollector,
+					},
+					Source: &commonv1beta1.SourceSpec{
+						Filter: &commonv1beta1.FilterSpec{},
+						FileSystemPath: &commonv1beta1.FileSystemPath{
+							Path:   "/absolute/path",
+							Kind:   commonv1beta1.FileKind,
+							Format: commonv1beta1.JsonFormat,
+						},
+					},
+				}
+				return i
+			}(),
+			Err:             true,
+			testDescription: "Invalid metrics filer for File metrics collector when file format is `JSON`",
 		},
 		// Valid FileMetricCollector
 		{
@@ -977,8 +1044,9 @@ func TestValidateMetricsCollector(t *testing.T) {
 					},
 					Source: &commonv1beta1.SourceSpec{
 						FileSystemPath: &commonv1beta1.FileSystemPath{
-							Path: "/absolute/path",
-							Kind: commonv1beta1.FileKind,
+							Path:   "/absolute/path",
+							Kind:   commonv1beta1.FileKind,
+							Format: commonv1beta1.JsonFormat,
 						},
 					},
 				}

--- a/pkg/webhook/v1beta1/experiment/validator/validator_test.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator_test.go
@@ -415,6 +415,7 @@ spec:
 	validTemplate4 := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(validJobStr, nil)
 	validTemplate5 := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(validJobStr, nil)
 	validTemplate6 := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(validJobStr, nil)
+	validTemplate7 := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(validJobStr, nil)
 
 	missedParameterTemplate := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(missedParameterJobStr, nil)
 	oddParameterTemplate := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(oddParameterJobStr, nil)
@@ -431,6 +432,7 @@ spec:
 		validTemplate4,
 		validTemplate5,
 		validTemplate6,
+		validTemplate7,
 		missedParameterTemplate,
 		oddParameterTemplate,
 		invalidParameterTemplate,
@@ -569,6 +571,16 @@ spec:
 			}(),
 			Err:             false,
 			testDescription: "Trial template contains Trial parameters when spec.parameters is empty",
+		},
+		// Trial template contains Trial metadata parameter substitution
+		{
+			Instance: func() *experimentsv1beta1.Experiment {
+				i := newFakeInstance()
+				i.Spec.TrialTemplate.TrialParameters[1].Reference = "${trialSpec.Name}"
+				return i
+			}(),
+			Err:             false,
+			testDescription: "Trial template contains Trial metadata reference as parameter",
 		},
 		// Trial Template doesn't contain parameter from trialParameters
 		// missedParameterTemplate case
@@ -798,8 +810,7 @@ func TestValidateMetricsCollector(t *testing.T) {
 					},
 					Source: &commonv1beta1.SourceSpec{
 						FileSystemPath: &commonv1beta1.FileSystemPath{
-							Path:   "not/absolute/path",
-							Format: commonv1beta1.TextFormat,
+							Path: "not/absolute/path",
 						},
 					},
 				}
@@ -826,27 +837,6 @@ func TestValidateMetricsCollector(t *testing.T) {
 			}(),
 			Err:             true,
 			testDescription: "Invalid path for TF event metrics collector",
-		},
-		// TfEventCollector invalid file format
-		{
-			Instance: func() *experimentsv1beta1.Experiment {
-				i := newFakeInstance()
-				i.Spec.MetricsCollectorSpec = &commonv1beta1.MetricsCollectorSpec{
-					Collector: &commonv1beta1.CollectorSpec{
-						Kind: commonv1beta1.TfEventCollector,
-					},
-					Source: &commonv1beta1.SourceSpec{
-						FileSystemPath: &commonv1beta1.FileSystemPath{
-							Path:   "/absolute/path",
-							Format: commonv1beta1.JsonFormat,
-							Kind:   commonv1beta1.DirectoryKind,
-						},
-					},
-				}
-				return i
-			}(),
-			Err:             true,
-			testDescription: "Invalid file format for TF event metrics collector",
 		},
 		// PrometheusMetricCollector invalid Port
 		{
@@ -942,9 +932,8 @@ func TestValidateMetricsCollector(t *testing.T) {
 							},
 						},
 						FileSystemPath: &commonv1beta1.FileSystemPath{
-							Path:   "/absolute/path",
-							Kind:   commonv1beta1.FileKind,
-							Format: commonv1beta1.TextFormat,
+							Path: "/absolute/path",
+							Kind: commonv1beta1.FileKind,
 						},
 					},
 				}
@@ -968,9 +957,8 @@ func TestValidateMetricsCollector(t *testing.T) {
 							},
 						},
 						FileSystemPath: &commonv1beta1.FileSystemPath{
-							Path:   "/absolute/path",
-							Kind:   commonv1beta1.FileKind,
-							Format: commonv1beta1.TextFormat,
+							Path: "/absolute/path",
+							Kind: commonv1beta1.FileKind,
 						},
 					},
 				}
@@ -978,49 +966,6 @@ func TestValidateMetricsCollector(t *testing.T) {
 			}(),
 			Err:             true,
 			testDescription: "One subexpression in metrics format",
-		},
-		// FileMetricCollector invalid file format
-		{
-			Instance: func() *experimentsv1beta1.Experiment {
-				i := newFakeInstance()
-				i.Spec.MetricsCollectorSpec = &commonv1beta1.MetricsCollectorSpec{
-					Collector: &commonv1beta1.CollectorSpec{
-						Kind: commonv1beta1.FileCollector,
-					},
-					Source: &commonv1beta1.SourceSpec{
-						FileSystemPath: &commonv1beta1.FileSystemPath{
-							Path:   "/absolute/path",
-							Kind:   commonv1beta1.FileKind,
-							Format: "invalid",
-						},
-					},
-				}
-				return i
-			}(),
-			Err:             true,
-			testDescription: "Invalid file format for File metrics collector",
-		},
-		// FileMetricCollector invalid metrics filter
-		{
-			Instance: func() *experimentsv1beta1.Experiment {
-				i := newFakeInstance()
-				i.Spec.MetricsCollectorSpec = &commonv1beta1.MetricsCollectorSpec{
-					Collector: &commonv1beta1.CollectorSpec{
-						Kind: commonv1beta1.FileCollector,
-					},
-					Source: &commonv1beta1.SourceSpec{
-						Filter: &commonv1beta1.FilterSpec{},
-						FileSystemPath: &commonv1beta1.FileSystemPath{
-							Path:   "/absolute/path",
-							Kind:   commonv1beta1.FileKind,
-							Format: commonv1beta1.JsonFormat,
-						},
-					},
-				}
-				return i
-			}(),
-			Err:             true,
-			testDescription: "Invalid metrics filer for File metrics collector when file format is `JSON`",
 		},
 		// Valid FileMetricCollector
 		{
@@ -1032,9 +977,8 @@ func TestValidateMetricsCollector(t *testing.T) {
 					},
 					Source: &commonv1beta1.SourceSpec{
 						FileSystemPath: &commonv1beta1.FileSystemPath{
-							Path:   "/absolute/path",
-							Kind:   commonv1beta1.FileKind,
-							Format: commonv1beta1.JsonFormat,
+							Path: "/absolute/path",
+							Kind: commonv1beta1.FileKind,
 						},
 					},
 				}


### PR DESCRIPTION
This PR fixes validation of Experiment when trial metadata used in template substitution.
Validator should not look for parameter in the spec.parameters if it is trial's metadata.

**Which issue(s) this PR fixes**:
Fixes #1844
